### PR TITLE
add squeezeAll warning

### DIFF
--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -454,6 +454,8 @@ type family SqueezeAll (shape :: [Nat]) :: [Nat] where
   SqueezeAll (x: xs) = x ': SqueezeAll xs
 
 -- | squeezeAll
+-- | Note: this function is unsafe; dimensions not known statically are retained in the type,
+-- | but may be squeezed out if they turn out 1 at run-time.
 --
 -- >>> dtype &&& shape $ squeezeAll (ones :: CPUTensor 'D.Float '[2,1,2,1,2])
 -- (Float,[2,2,2])


### PR DESCRIPTION
[slack discussion](https://hasktorch.slack.com/archives/C75PY1W0J/p1586556310092600):

> `squeezeAll`  is unsafe, the type squeezes out known `1`s but leaves in unknowns, while at run-time those that then turn out 1 are also squeezed out.
5 replies

> (I'm not sure this function can be safely typed, as essentially the number of dimensions suddenly becomes unknown...)

> I'm pretty much gonna put this one on my blacklist

> a typed solution here would mean some new type for a dimension like `[a, b?, c, d]` , but doubting that's gonna happen anytime soon, might the best option for now just be to put a disclaimer in its docstring?

> alternatively, we can make this function safe by restricting its use to `KnownShape`s, demanding that all dimensions are statically known.

> oh, `KnownShape`  doesn't require `KnownNat`s, so I guess this needs like some SuperExactlyStaticallyKnownShape. and I don't really know how subclassing like that works if we wanna be able to check for a given tensor whether its shape just so happens to have all static dimensions.
